### PR TITLE
fixing error/bug in ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ VOLUME ["/ezstream", "/music"]
 
 USER $UID:$GID
 
-ENTRYPOINT ["/usr/bin/ezstream" "-c" "/ezstream/ezstream.xml"]
+ENTRYPOINT ["/usr/bin/ezstream", "-c", "/ezstream/ezstream.xml"]


### PR DESCRIPTION
added missing commas in ENTRYPOINT - without the commas the container was unable to start